### PR TITLE
Feature/s3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ terraform.rc
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,terraform
+
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ terraform.rc
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,terraform
 
 .idea/*
+.terraform.lock.hcl
+

--- a/main.tf
+++ b/main.tf
@@ -110,3 +110,13 @@ resource "aws_rds_cluster_instance" "instances" {
   performance_insights_enabled = var.performance_insights_enabled
   db_subnet_group_name         = aws_db_subnet_group.default.name
 }
+
+resource "aws_rds_cluster_role_association" "s3_integration" {
+  count = var.s3_import_role_arn != null ? 1 : 0
+
+  db_cluster_identifier = aws_rds_cluster.prod.id
+  feature_name          = "LOAD DATA FROM S3"
+  role_arn = var.s3_import_role_arn
+
+  depends_on = [aws_rds_cluster.prod]
+}

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_rds_cluster_role_association" "s3_integration" {
   count = var.s3_import_role_arn != null ? 1 : 0
 
   db_cluster_identifier = aws_rds_cluster.prod.id
-  feature_name          = ""
+  feature_name          = "" # see https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/273#issuecomment-1062890486
   role_arn              = var.s3_import_role_arn
 
   depends_on = [aws_rds_cluster.prod]

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,15 @@ resource "aws_rds_cluster_parameter_group" "default" {
     value        = "1073741824"
     apply_method = "pending-reboot"
   }
+
+  dynamic "parameter" {
+    for_each = var.s3_import_role_arn != null ? ["aurora_load_from_s3_role", "aws_default_s3_role"] : []
+    content {
+      name         = parameter.value
+      value        = var.s3_import_role_arn
+      apply_method = "pending-reboot"
+    }
+  }
 }
 
 resource "aws_db_parameter_group" "default" {
@@ -76,7 +85,7 @@ resource "aws_rds_cluster" "prod" {
   master_username                  = var.admin_username
   master_password                  = random_string.rds_password.result
   storage_encrypted                = true
-  vpc_security_group_ids           = [aws_security_group.rds_access.id]
+  vpc_security_group_ids = [aws_security_group.rds_access.id]
   db_cluster_parameter_group_name  = aws_rds_cluster_parameter_group.default.name
   db_instance_parameter_group_name = aws_db_parameter_group.default.name
   db_subnet_group_name             = aws_db_subnet_group.default.name
@@ -97,7 +106,7 @@ resource "aws_rds_cluster_instance" "instances" {
   engine                       = aws_rds_cluster.prod.engine
   engine_version               = aws_rds_cluster.prod.engine_version
   db_parameter_group_name      = aws_db_parameter_group.default.name
-  depends_on                   = [aws_rds_cluster.prod]
+  depends_on = [aws_rds_cluster.prod]
   performance_insights_enabled = var.performance_insights_enabled
   db_subnet_group_name         = aws_db_subnet_group.default.name
 }

--- a/main.tf
+++ b/main.tf
@@ -110,3 +110,17 @@ resource "aws_rds_cluster_instance" "instances" {
   performance_insights_enabled = var.performance_insights_enabled
   db_subnet_group_name         = aws_db_subnet_group.default.name
 }
+
+resource "aws_rds_cluster_role_association" "s3_integration" {
+  # Create this association only if an s3_import_role_arn is provided
+  count = var.s3_import_role_arn != null ? 1 : 0
+
+  db_cluster_identifier = aws_rds_cluster.prod.id
+  feature_name          = "s3Import" # For Aurora, this is typically for importing data from S3.
+                                    # Other possible values exist for other RDS engines or features (e.g., s3Export).
+  role_arn              = var.s3_import_role_arn
+
+  # Explicitly depend on the cluster. The role is created outside this module,
+  # so Terraform will know the role_arn value.
+  depends_on = [aws_rds_cluster.prod]
+}

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_rds_cluster_role_association" "s3_integration" {
   count = var.s3_import_role_arn != null ? 1 : 0
 
   db_cluster_identifier = aws_rds_cluster.prod.id
-  # feature_name          = ""
+  feature_name          = ""
   role_arn = var.s3_import_role_arn
 
   depends_on = [aws_rds_cluster.prod]

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 
   dynamic "parameter" {
-    for_each = var.s3_import_role_arn != null ? ["aurora_load_from_s3_role", "aws_default_s3_role"] : []
+    for_each = var.s3_import_role_arn != null ? ["aws_default_s3_role"] : []
     content {
       name         = parameter.value
       value        = var.s3_import_role_arn

--- a/main.tf
+++ b/main.tf
@@ -66,8 +66,7 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 
   dynamic "parameter" {
-    for_each = var.enable_s3_import_integration && var.s3_import_role_arn != null ?
-      { "aws_default_s3_role" = var.s3_import_role_arn } : {}
+    for_each = (var.enable_s3_import_integration && var.s3_import_role_arn != null) ? { "aws_default_s3_role" = var.s3_import_role_arn } : {}
     content {
       name         = parameter.key
       value        = parameter.value

--- a/main.tf
+++ b/main.tf
@@ -110,17 +110,3 @@ resource "aws_rds_cluster_instance" "instances" {
   performance_insights_enabled = var.performance_insights_enabled
   db_subnet_group_name         = aws_db_subnet_group.default.name
 }
-
-resource "aws_rds_cluster_role_association" "s3_integration" {
-  # Create this association only if an s3_import_role_arn is provided
-  count = var.s3_import_role_arn != null ? 1 : 0
-
-  db_cluster_identifier = aws_rds_cluster.prod.id
-  feature_name          = "s3Import" # For Aurora, this is typically for importing data from S3.
-                                    # Other possible values exist for other RDS engines or features (e.g., s3Export).
-  role_arn              = var.s3_import_role_arn
-
-  # Explicitly depend on the cluster. The role is created outside this module,
-  # so Terraform will know the role_arn value.
-  depends_on = [aws_rds_cluster.prod]
-}

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_rds_cluster_role_association" "s3_integration" {
   count = var.s3_import_role_arn != null ? 1 : 0
 
   db_cluster_identifier = aws_rds_cluster.prod.id
-  feature_name          = "LOAD DATA FROM S3"
+  # feature_name          = ""
   role_arn = var.s3_import_role_arn
 
   depends_on = [aws_rds_cluster.prod]

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,16 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 }
 
+resource "aws_rds_cluster_role_association" "s3_integration" {
+  count = var.s3_import_role_arn != null ? 1 : 0
+
+  db_cluster_identifier = aws_rds_cluster.prod.id
+  feature_name          = ""
+  role_arn              = var.s3_import_role_arn
+
+  depends_on = [aws_rds_cluster.prod]
+}
+
 resource "aws_db_parameter_group" "default" {
   name        = var.applicationName
   family      = "aurora-mysql8.0"
@@ -109,14 +119,4 @@ resource "aws_rds_cluster_instance" "instances" {
   depends_on = [aws_rds_cluster.prod]
   performance_insights_enabled = var.performance_insights_enabled
   db_subnet_group_name         = aws_db_subnet_group.default.name
-}
-
-resource "aws_rds_cluster_role_association" "s3_integration" {
-  count = var.s3_import_role_arn != null ? 1 : 0
-
-  db_cluster_identifier = aws_rds_cluster.prod.id
-  feature_name          = ""
-  role_arn = var.s3_import_role_arn
-
-  depends_on = [aws_rds_cluster.prod]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,9 @@ variable "performance_insights_enabled" {
   type        = bool
   default     = false
 }
+
+variable "s3_import_role_arn" {
+  description = "Optional. The ARN of the IAM role to be used for S3 import operations (e.g., LOAD DATA FROM S3). This will be set for aurora_load_from_s3_role and aws_default_s3_role."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,9 @@ variable "s3_import_role_arn" {
   type        = string
   default     = null
 }
+
+variable "enable_s3_import_integration" {
+  description = "If true, enables the S3 import integration by associating the s3_import_role_arn and setting the necessary cluster parameter. s3_import_role_arn must be provided if this is true."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "vpc_id" {
 
 variable "vpc_subnet_ids" {
   description = "The IDs of the subnets to place the db instances"
-  type        = list(string)
+  type = list(string)
 }
 
 variable "admin_username" {
@@ -18,6 +18,7 @@ variable "admin_username" {
   type        = string
   default     = "admin"
 }
+
 variable "db_name" {
   description = "The name of the database"
   type        = string
@@ -48,16 +49,10 @@ variable "performance_insights_enabled" {
   default     = false
 }
 
-variable "s3_import_role_arn" {
-  description = "Optional. The ARN of the IAM role to be used for S3 import operations (e.g., LOAD DATA FROM S3). This will be set for aurora_load_from_s3_role and aws_default_s3_role."
-  type        = string
-  default     = null
-}
-
-variable "enable_s3_import_integration" {
-  description = "If true, enables the S3 import integration by associating the s3_import_role_arn and setting the necessary cluster parameter. s3_import_role_arn must be provided if this is true."
-  type        = bool
-  default     = false
+variable "s3_import_bucket_names" {
+  description = "List of S3 bucket names that RDS should have access to for import operations (e.g., LOAD DATA FROM S3). If provided (length > 0), S3 import integration will be automatically enabled with all necessary IAM roles, policies, and security group rules."
+  type = list(string)
+  default = []
 }
 
 variable "aurora_mysql_engine_version" {
@@ -69,11 +64,11 @@ variable "aurora_mysql_engine_version" {
 variable "additional_egress_rules" {
   description = "Additional egress rules to add to the RDS security group"
   type = list(object({
-    description     = string
-    from_port       = number
-    to_port         = number
-    protocol        = string
-    cidr_blocks     = optional(list(string), [])
+    description = string
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = optional(list(string), [])
     prefix_list_ids = optional(list(string), [])
   }))
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -60,16 +60,3 @@ variable "aurora_mysql_engine_version" {
   type        = string
   default     = "8.0.mysql_aurora.3.08.2"
 }
-
-variable "additional_egress_rules" {
-  description = "Additional egress rules to add to the RDS security group"
-  type = list(object({
-    description = string
-    from_port   = number
-    to_port     = number
-    protocol    = string
-    cidr_blocks = optional(list(string), [])
-    prefix_list_ids = optional(list(string), [])
-  }))
-  default = []
-}

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,16 @@ variable "aurora_mysql_engine_version" {
   type        = string
   default     = "8.0.mysql_aurora.3.08.2"
 }
+
+variable "additional_egress_rules" {
+  description = "Additional egress rules to add to the RDS security group"
+  type = list(object({
+    description     = string
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    cidr_blocks     = optional(list(string), [])
+    prefix_list_ids = optional(list(string), [])
+  }))
+  default = []
+}


### PR DESCRIPTION
**Add support for RDS imports from S3**

This PR adds the ability for the RDS instance to import data directly from S3 buckets.

To use it, pass a list of bucket names to the new `s3_import_bucket_names` variable. The module will automatically create the necessary IAM role and policies for the integration.

**Usage:**

```hcl
s3_import_bucket_names = ["my-data-import-bucket"]
```